### PR TITLE
Fixes positioning of .header-icons-mobile

### DIFF
--- a/assets/main.css
+++ b/assets/main.css
@@ -1018,6 +1018,7 @@ li.sale-noti > a {
   display: flex;
   align-items: center;
   margin-right: 15px;
+  position: relative;
 }
 .linedivide2 {
   display: block;


### PR DESCRIPTION
Fixes a bug where position relative is missing from .header-icons-mobile. This style is present in the HTML only version and fixes the current layout issue present when using on Shopify.