### PR TITLE
Limiting number of sample blog posts on home screen

### DIFF
--- a/snippets/blog-1.liquid
+++ b/snippets/blog-1.liquid
@@ -6,7 +6,7 @@
       </h3>
     </div>
     <div class="row">
-      {% for article in blogs[section.settings.blog].articles %}
+      {% for article in blogs[section.settings.blog].articles: limit 3 %}
       <div class="col-sm-10 col-md-4 p-b-30 m-l-r-auto">
         <!-- Block3 -->
         <div class="block3">

--- a/snippets/blog-2.liquid
+++ b/snippets/blog-2.liquid
@@ -6,7 +6,7 @@
       </h3>
     </div>
     <div class="row">
-      {% for article in blogs[section.settings.blog].articles %}
+      {% for article in blogs[section.settings.blog].articles: limit 3 %}
       <div class="col-sm-10 col-md-4 p-b-30 m-l-r-auto">
         <!-- Block3 -->
         <div class="block3">


### PR DESCRIPTION
Limiting the number of blog posts shown on the home screen to just 3 as per the template website: https://fashe-theme.myshopify.com. Prior to this change, it displayed all of the blog posts that are written on the home page, as opposed to the latest 3.